### PR TITLE
feat: Add GitHub Action to build and publish Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,6 @@
 name: Docker Image CI
 
-on: [push] # Trigger on pushes to any branch
+on: [push, pull_request]
 
 jobs:
   build_and_push:
@@ -26,11 +26,15 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            # For main branch, use 'latest' and commit SHA
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,prefix=,suffix=,format=short,enable=${{ github.ref == 'refs/heads/main' }}
-            # For other branches, use branch_name-commit_SHA
-            type=ref,event=branch,prefix=,suffix=-${{ github.sha }},format=short,enable=${{ github.ref != 'refs/heads/main' }}
+            # For push to main: latest and sha-short
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=sha,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+            # For push to other branches: branchname-sha-short (e.g., mybranch-abc1234)
+            type=ref,event=branch,suffix=-{{sha-short}},enable=${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+
+            # For pull requests: pr-number-sha-short (e.g., pr-123-abc1234)
+            type=ref,event=pr,suffix=-{{sha-short}}
 
 
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Docker Image CI
+
+on: [push] # Trigger on pushes to any branch
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Needed to push to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # For main branch, use 'latest' and commit SHA
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=,suffix=,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+            # For other branches, use branch_name-commit_SHA
+            type=ref,event=branch,prefix=,suffix=-${{ github.sha }},format=short,enable=${{ github.ref != 'refs/heads/main' }}
+
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Readme.md
+++ b/Readme.md
@@ -89,17 +89,19 @@ This repository is configured with a GitHub Action that automatically builds and
 
 ### Triggers
 
-The workflow is triggered on every push to any branch in the repository.
+The workflow is triggered on every push to any branch and on every pull request event (e.g., opened, synchronized) in the repository.
 
 ### Image Tagging
 
-Images are tagged based on the branch that triggered the build:
+Images are tagged based on the event and branch that triggered the build:
 
 *   **Pushes to `main` branch:**
-    *   `ghcr.io/OWNER/REPO:latest`
-    *   `ghcr.io/OWNER/REPO:<commit_sha_short>`
+    *   `ghcr.io/cfullelove/video-audio-extractor:latest`
+    *   `ghcr.io/cfullelove/video-audio-extractor:<commit_sha_short>` (e.g., `ghcr.io/cfullelove/video-audio-extractor:abc1234`)
 *   **Pushes to other branches (e.g., `feature-branch`):**
-    *   `ghcr.io/OWNER/REPO:feature-branch-<commit_sha_short>`
+    *   `ghcr.io/cfullelove/video-audio-extractor:feature-branch-<commit_sha_short>` (e.g., `ghcr.io/cfullelove/video-audio-extractor:feature-branch-abc1234`)
+*   **Pull request events (e.g., for PR #123):**
+    *   `ghcr.io/cfullelove/video-audio-extractor:pr-123-<commit_sha_short>` (e.g., `ghcr.io/cfullelove/video-audio-extractor:pr-123-abc1234`)
 
 (Replace `OWNER/REPO` with the actual repository owner and name, which is `${{ github.repository }}` in the workflow.)
 
@@ -109,18 +111,21 @@ You can pull the image using Docker:
 
 ```bash
 # Example for the latest image from the main branch
-docker pull ghcr.io/OWNER/REPO:latest
+docker pull ghcr.io/cfullelove/video-audio-extractor:latest
 
 # Example for a specific commit on the main branch
-docker pull ghcr.io/OWNER/REPO:abcdefg
+docker pull ghcr.io/cfullelove/video-audio-extractor:abcdefg
 
 # Example for a feature branch
-docker pull ghcr.io/OWNER/REPO:feature-branch-abcdefg
+docker pull ghcr.io/cfullelove/video-audio-extractor:feature-branch-abcdefg
+
+# Example for a pull request build
+docker pull ghcr.io/cfullelove/video-audio-extractor:pr-123-abcdefg
 ```
 
 To run the container:
 
 ```bash
-docker run -d -p 5000:5000 ghcr.io/OWNER/REPO:latest
+docker run -d -p 5000:5000 ghcr.io/cfullelove/video-audio-extractor:latest
 ```
 This will start the application, and it will be accessible at `http://localhost:5000`.

--- a/Readme.md
+++ b/Readme.md
@@ -82,3 +82,45 @@ Do not expose it to the public internet without additional security layers.
 MIT License. Do what you like — no warranty provided.
 
 Created with 💻 + ☕ for quick and simple local audio extraction.
+
+## Automated Container Image Publishing
+
+This repository is configured with a GitHub Action that automatically builds and publishes a Docker container image to the GitHub Container Registry (GHCR).
+
+### Triggers
+
+The workflow is triggered on every push to any branch in the repository.
+
+### Image Tagging
+
+Images are tagged based on the branch that triggered the build:
+
+*   **Pushes to `main` branch:**
+    *   `ghcr.io/OWNER/REPO:latest`
+    *   `ghcr.io/OWNER/REPO:<commit_sha_short>`
+*   **Pushes to other branches (e.g., `feature-branch`):**
+    *   `ghcr.io/OWNER/REPO:feature-branch-<commit_sha_short>`
+
+(Replace `OWNER/REPO` with the actual repository owner and name, which is `${{ github.repository }}` in the workflow.)
+
+### Using the Image
+
+You can pull the image using Docker:
+
+```bash
+# Example for the latest image from the main branch
+docker pull ghcr.io/OWNER/REPO:latest
+
+# Example for a specific commit on the main branch
+docker pull ghcr.io/OWNER/REPO:abcdefg
+
+# Example for a feature branch
+docker pull ghcr.io/OWNER/REPO:feature-branch-abcdefg
+```
+
+To run the container:
+
+```bash
+docker run -d -p 5000:5000 ghcr.io/OWNER/REPO:latest
+```
+This will start the application, and it will be accessible at `http://localhost:5000`.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the building and publishing of a Docker container image to the GitHub Container Registry (GHCR).

Key features:
- The workflow is triggered on every push to any branch.
- Images are tagged as `ghcr.io/OWNER/REPO:latest` and `ghcr.io/OWNER/REPO:<commit_sha>` for pushes to the `main` branch.
- For other branches, images are tagged as `ghcr.io/OWNER/REPO:BRANCH_NAME-<commit_sha>`.
- The workflow uses the built-in `secrets.GITHUB_TOKEN` for authentication with GHCR.

The `Readme.md` has also been updated to document this new CI process, including how images are tagged and how to pull and run them.